### PR TITLE
Broaden dword value syntax

### DIFF
--- a/syntaxes/reg.tmLanguage
+++ b/syntaxes/reg.tmLanguage
@@ -229,7 +229,7 @@
 
 			</dict>
 			<key>match</key>
-			<string>^(\s*(["']?)(.+?)(["']?)\s*(=))?\s*((-)|((["'])(.*?)(["']))|(((?i:dword))(\:)([\dabcdefABCDEF]{8}))|(((?i:hex))((\()([\d]*)(\)))?(\:)(.*?)(\\?)))\s*(;.*)?$</string>
+			<string>^(\s*(["']?)(.+?)(["']?)\s*(=))?\s*((-)|((["'])(.*?)(["']))|(((?i:dword))(\:)\s*([\dabcdefABCDEF]{1,8}))|(((?i:hex))((\()([\d]*)(\)))?(\:)(.*?)(\\?)))\s*(;.*)?$</string>
 			<key>name</key>
 			<string>meta.declaration.reg</string>
 		</dict>


### PR DESCRIPTION
Hey :)

This PR let's dword values use less than 8 hex digits,
and have spaces between the colon and the value.

I've checked, this works with regedit as expected.

I don't like padding dword values with zeros, especially if they are just a boolean,
so I thought I'd contribute a PR.

Thanks for the extension!