### PR TITLE
Loads extension only when `reg` files are opened instead of on VS Code start up

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         ]
     },
     "activationEvents": [
-        "*"
+        "onLanguage:reg"
     ],
     "main": "./out/extension",
     "scripts": {


### PR DESCRIPTION
Fixes #12