### PR TITLE
Fix placeholders in snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -7,22 +7,22 @@
     "A HKEY_CURRENT_CONFIG hive": {
         "prefix": "hkey_current_config",
         "description": "Create a section beginning with `HKEY_CURRENT_CONFIG`",
-        "body": "[HKEY_CURRENT_CONFIG\\${1:path}]\n"
+        "body": "[HKEY_CURRENT_CONFIG\\\\${1:path}]\n"
     },
     "A HKEY_CURRENT_USER hive": {
         "prefix": "hkey_current_user",
         "description": "Create a section beginning with `HKEY_CURRENT_USER`",
-        "body": "[HKEY_CURRENT_USER\\${1:path}]\n"
+        "body": "[HKEY_CURRENT_USER\\\\${1:path}]\n"
     },
     "A HKEY_LOCAL_MACHINE hive": {
         "prefix": "hkey_local_machine",
         "description": "Create a section beginning with `HKEY_LOCAL_MACHINE`",
-        "body": "[HKEY_LOCAL_MACHINE\\${1:path}]\n"
+        "body": "[HKEY_LOCAL_MACHINE\\\\${1:path}]\n"
     },
     "A HKEY_USERS hive": {
         "prefix": "hkey_users",
         "description": "Create a section beginning with `HKEY_USERS`",
-        "body": "[HKEY_USERS\\${1:path}]\n"
+        "body": "[HKEY_USERS\\\\${1:path}]\n"
     },
     "A key-value pair": {
         "prefix": "key",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -7,22 +7,22 @@
     "A HKEY_CURRENT_CONFIG hive": {
         "prefix": "hkey_current_config",
         "description": "Create a section beginning with `HKEY_CURRENT_CONFIG`",
-        "body": "[HKEY_CURRENT_CONFIG\\\\${1:path}]\n"
+        "body": "[HKEY_CURRENT_CONFIG\\\\${1:path\\to\\key}]\n"
     },
     "A HKEY_CURRENT_USER hive": {
         "prefix": "hkey_current_user",
         "description": "Create a section beginning with `HKEY_CURRENT_USER`",
-        "body": "[HKEY_CURRENT_USER\\\\${1:path}]\n"
+        "body": "[HKEY_CURRENT_USER\\\\${1:path\\to\\key}]\n"
     },
     "A HKEY_LOCAL_MACHINE hive": {
         "prefix": "hkey_local_machine",
         "description": "Create a section beginning with `HKEY_LOCAL_MACHINE`",
-        "body": "[HKEY_LOCAL_MACHINE\\\\${1:path}]\n"
+        "body": "[HKEY_LOCAL_MACHINE\\\\${1:path\\to\\key}]\n"
     },
     "A HKEY_USERS hive": {
         "prefix": "hkey_users",
         "description": "Create a section beginning with `HKEY_USERS`",
-        "body": "[HKEY_USERS\\\\${1:path}]\n"
+        "body": "[HKEY_USERS\\\\${1:path\\to\\key}]\n"
     },
     "A key-value pair": {
         "prefix": "key",


### PR DESCRIPTION
Now they work properly:

![image](https://user-images.githubusercontent.com/42812113/163707995-1ddb96d7-0627-4512-8dc2-7ff903fe9fae.png)

